### PR TITLE
fix: Cloud Run実行後のConsole URLが404になる問題を修正

### DIFF
--- a/.github/workflows/exec-ageage-collector.yml
+++ b/.github/workflows/exec-ageage-collector.yml
@@ -15,6 +15,7 @@ env:
   WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
   SERVICE_ACCOUNT: ${{ secrets.SERVICE_ACCOUNT }}
   RUN_SERVICE_ACCOUNT: ${{ secrets.RUN_SERVICE_ACCOUNT }}
+  PROJECT_ID: ${{ secrets.PROJECT_ID }}
   IMAGE_HOST: "asia-northeast1-docker.pkg.dev"
   IMAGE_TAG_BASE: ${{ secrets.IMAGE_TAG_BASE }} # 例. プロジェクトID/artifact_registry名/イメージ名
   GCP_REGION: asia-northeast1
@@ -42,6 +43,7 @@ jobs:
       - name: Exec Ageage Collector
         id: ageage-collector
         run: |
+          gcloud config set project $PROJECT_ID
           gcloud config set run/region $GCP_REGION
           set +e
           gcloud run jobs describe ageagecli --quiet >/dev/null


### PR DESCRIPTION
## 概要
GitHub ActionsでCloud Runジョブ実行後に表示されるGoogle Cloud ConsoleのURLが404エラーになる問題を修正しました。

## 問題の原因
`exec-ageage-collector.yml`でgcloud run jobsを実行する際、プロジェクトIDが明示的に設定されていなかったため、gcloudがプロジェクト番号（358690415971）を使用してURLを生成していました。Google Cloud ConsoleはプロジェクトIDを期待するため、404エラーが発生していました。

## 修正内容
- `PROJECT_ID`環境変数を追加
- `gcloud config set project $PROJECT_ID`コマンドを追加してプロジェクトIDを明示的に設定

## 必要な追加作業
GitHub Actionsのシークレットに`PROJECT_ID`を追加する必要があります：
1. GitHub リポジトリの Settings → Secrets and variables → Actions に移動
2. `PROJECT_ID`という名前でGCPプロジェクトIDを追加

## テスト
- [ ] GitHub Actionsで`exec-ageage-collector`ワークフローを実行
- [ ] Cloud Run実行後のConsole URLが正しく機能することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)