### PR TITLE
fix: AuthContextのインポートエラーを修正

### DIFF
--- a/apps/frontend/hooks/use-meshi-like-state.ts
+++ b/apps/frontend/hooks/use-meshi-like-state.ts
@@ -2,7 +2,7 @@
 
 import { request } from 'graphql-request'
 import { useEffect, useState } from 'react'
-import { useAuth } from '@/contexts/AuthContext'
+import { useAuth } from '@/contexts/AuthContextDynamic'
 
 const MeshiLikeStateQuery = `
   query MeshiLikeState($meshiId: ID!) {


### PR DESCRIPTION
use-meshi-like-state.tsで静的インポート版のAuthContextを使用していたため、
SSR時にFirebase初期化エラーが発生していた問題を修正。
AuthContextDynamicを使用するように変更し、エラーを解消。

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>