### PR TITLE
fix: 無限スクロールでの重複keyエラーを修正

### DIFF
--- a/apps/frontend/components/auth/AuthMenuWrapper.tsx
+++ b/apps/frontend/components/auth/AuthMenuWrapper.tsx
@@ -4,10 +4,13 @@ import dynamic from 'next/dynamic'
 import { MenubarItem } from '@/components/ui/menubar'
 
 // AuthMenuを動的インポートに変更し、SSRを無効化
-const AuthMenu = dynamic(() => import('./AuthMenu').then(mod => ({ default: mod.AuthMenu })), {
-  ssr: false,
-  loading: () => <MenubarItem disabled>読み込み中...</MenubarItem>
-})
+const AuthMenu = dynamic(
+  () => import('./AuthMenu').then((mod) => ({ default: mod.AuthMenu })),
+  {
+    ssr: false,
+    loading: () => <MenubarItem disabled>読み込み中...</MenubarItem>,
+  },
+)
 
 export function AuthMenuWrapper() {
   return <AuthMenu />

--- a/apps/frontend/components/meshi-card.tsx
+++ b/apps/frontend/components/meshi-card.tsx
@@ -8,10 +8,13 @@ import { Card, CardContent, CardFooter } from '@/components/ui/card'
 import { type FragmentType, graphql, useFragment } from '@/src/gql'
 
 // LikeButtonを動的インポートに変更し、SSRを無効化
-const LikeButton = dynamic(() => import('./like-button').then(mod => ({ default: mod.LikeButton })), {
-  ssr: false,
-  loading: () => <div className="w-6 h-6" /> // ローディング中のプレースホルダー
-})
+const LikeButton = dynamic(
+  () => import('./like-button').then((mod) => ({ default: mod.LikeButton })),
+  {
+    ssr: false,
+    loading: () => <div className="w-6 h-6" />, // ローディング中のプレースホルダー
+  },
+)
 
 export const MeshiCardFragment = graphql(`
   fragment MeshiCard on Meshi {

--- a/apps/frontend/components/meshi-list-container.tsx
+++ b/apps/frontend/components/meshi-list-container.tsx
@@ -41,7 +41,11 @@ export function MeshiListContainer({
         const data = await loadMoreAction(pageInfo.endCursor, 20, query)
         const newMeshis = data.meshis.edges.map((edge) => edge.node)
 
-        setMeshis((prev) => [...prev, ...newMeshis])
+        setMeshis((prev) => {
+          const existingIds = new Set(prev.map(meshi => meshi.id))
+          const uniqueNewMeshis = newMeshis.filter(meshi => !existingIds.has(meshi.id))
+          return [...prev, ...uniqueNewMeshis]
+        })
         setPageInfo(data.meshis.pageInfo)
       } catch (error) {
         console.error('Failed to load more meshis:', error)


### PR DESCRIPTION
- MeshiListContainerで新しいデータを追加する際の重複チェックを実装
- 既存のIDをSetで管理し、重複するmeshiデータを除外
- 'same key'エラーによるReactの警告を解決
- AuthMenuWrapperとMeshiCardのフォーマットを統一

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>