### PR TITLE
fix: プロダクション環境での無限スクロール問題を修正

### DIFF
--- a/apps/frontend/app/actions/meshi.ts
+++ b/apps/frontend/app/actions/meshi.ts
@@ -20,10 +20,9 @@ export async function loadMoreMeshis(
     process.env.BACKEND_ENDPOINT ?? 'http://localhost:44000/graphql'
 
   const client = new GraphQLClient(backendEndpoint, {
-    // biome-ignore lint/suspicious/noExplicitAny: Next.js fetch cache requires any for generic fetch signature
-    fetch: cache(async (url: any, params: any) =>
-      fetch(url, { ...params, next: { revalidate: 60 } }),
-    ),
+    // Server Actionではキャッシュを無効化（無限スクロール対応）
+    fetch: async (url: any, params: any) =>
+      fetch(url, { ...params, cache: 'no-store' }),
   })
 
   // 変数オブジェクトを明示的に型付け

--- a/apps/frontend/components/meshi-list-container.tsx
+++ b/apps/frontend/components/meshi-list-container.tsx
@@ -48,7 +48,12 @@ export function MeshiListContainer({
         })
         setPageInfo(data.meshis.pageInfo)
       } catch (error) {
-        console.error('Failed to load more meshis:', error)
+        console.error('Failed to load more meshis:', {
+          error,
+          cursor: pageInfo.endCursor,
+          hasNextPage: pageInfo.hasNextPage,
+          query,
+        })
       } finally {
         setIsLoadingMore(false)
       }


### PR DESCRIPTION
## Summary
- プロダクション環境で無限スクロールが12件以降動作しない問題を修正
- Server Actionのキャッシュが原因でcursorが変わっても同じ結果が返されていた問題を解決

## 変更内容
- `loadMoreMeshis` Server ActionでReact cacheを無効化し、`cache: 'no-store'`に変更
- エラーハンドリングを強化してデバッグ情報（cursor、hasNextPage、query）を追加

## Test plan
- [ ] ローカル環境で無限スクロールが正常に動作することを確認
- [ ] プロダクション環境デプロイ後、12件以降も無限スクロールが動作することを確認
- [ ] エラーが発生した場合、詳細な情報がログに出力されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)