### PR TITLE
fix: correct production meshi pagination with composite cursor and no-store

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Monorepo managed by `pnpm` and `turbo`.
+- Apps: `apps/frontend` (Next.js 15), `apps/backend` (Fastify + GraphQL Yoga + Prisma).
+- Shared/other: `components/**`, `docs/**`, `.github/workflows/**` (CI), `compose.yml` (services).
+- Test roots: backend unit tests live under `apps/backend/src/**/*.test.ts`; frontend E2E under `apps/frontend/e2e/**`.
+
+## Build, Test, and Development Commands
+- Install: `pnpm install`
+- Start services (DB + Firebase Emulator): `make up` • Full dev: `make dev`
+- Run all apps (turbo): `pnpm dev` • Build all: `pnpm build`
+- Backend only: `pnpm --filter backend dev | build | start`
+- DB migrations: `pnpm --filter backend db:migrate:dev`
+- Tests:
+  - Backend (Vitest): `pnpm --filter backend test`
+  - Frontend E2E (Playwright): `pnpm --filter frontend exec playwright install && pnpm --filter frontend exec playwright test`
+
+## Coding Style & Naming Conventions
+- Language: TypeScript across apps.
+- Formatter/Linter: Biome at root (`pnpm lint`, `pnpm format`); frontend additionally uses ESLint Next config.
+- Formatting (Biome): 2-space indent, line width 80, single quotes, semicolons as needed.
+- File naming: prefer kebab-case for files/dirs; React component names are PascalCase; tests end with `.test.ts`.
+
+## Testing Guidelines
+- Backend: Vitest for unit tests; place tests near source (e.g., `src/services/foo.test.ts`).
+- Frontend: Playwright for E2E in `apps/frontend/e2e`; configure `BASE_URL` when needed.
+- Aim to cover core business logic and error paths. Keep tests deterministic; use Docker emulators where applicable.
+
+## Commit & Pull Request Guidelines
+- Commit style: use concise prefixes seen in history (`feat:`, `fix:`, `chore:`, `refactor:`, `debug:`). One change per commit when practical.
+- PRs: include clear description, linked issues (e.g., `Closes #123`), and screenshots for UI changes.
+- Pre-PR checklist: `pnpm format`, `pnpm lint`, backend tests pass, Playwright checks relevant flows.
+
+## Security & Configuration Tips
+- Never commit secrets. Copy env files and edit locally:
+  - Frontend: `cp apps/frontend/.env.local.example apps/frontend/.env.local`
+  - Backend: `cp apps/backend/.env.example apps/backend/.env`
+- Local endpoints: FE `http://localhost:33000`, BE `http://localhost:44000`, Emulator UI `http://localhost:4000`.
+

--- a/apps/backend/src/schema/meshi/resolvers/Query/meshis.test.ts
+++ b/apps/backend/src/schema/meshi/resolvers/Query/meshis.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { meshis } from './meshis'
+import { decodeMeshiCursor } from '../../../../lib/cursor'
+
+function d(s: string) {
+  return new Date(s)
+}
+
+describe('Query.meshis resolver (composite cursor pagination)', () => {
+  const prismaMock: any = {
+    meshi: {
+      findMany: vi.fn(),
+      count: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    $queryRaw: vi.fn(),
+  }
+  const ctx: any = { prisma: prismaMock }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const callResolver = async (resolver: any, parent: any, args: any, ctx: any) => {
+    if (typeof resolver === 'function') return await resolver(parent, args, ctx, undefined)
+    if (resolver && typeof resolver.resolve === 'function') return await resolver.resolve(parent, args, ctx, undefined)
+    throw new Error('Invalid resolver')
+  }
+
+  it('returns hasNextPage=true when more items exist and uses composite endCursor', async () => {
+    // Data ordered by publishedDate desc, id desc
+    const items = [
+      { id: 3, title: 'A', imageUrl: '', storeName: '', address: '', siteUrl: '', publishedDate: d('2025-02-03T00:00:00Z'), latitude: 0, longitude: 0, createdAt: d('2025-02-03T00:00:00Z') },
+      { id: 2, title: 'B', imageUrl: '', storeName: '', address: '', siteUrl: '', publishedDate: d('2025-02-02T00:00:00Z'), latitude: 0, longitude: 0, createdAt: d('2025-02-02T00:00:00Z') },
+      { id: 1, title: 'C', imageUrl: '', storeName: '', address: '', siteUrl: '', publishedDate: d('2025-02-01T00:00:00Z'), latitude: 0, longitude: 0, createdAt: d('2025-02-01T00:00:00Z') },
+    ]
+
+    prismaMock.meshi.count.mockResolvedValue(items.length)
+    prismaMock.meshi.findMany.mockResolvedValue(items)
+
+    const result = await callResolver(meshis as any, {}, { first: 2 }, ctx)
+
+    expect(result.edges).toHaveLength(2)
+    expect(result.pageInfo.hasNextPage).toBe(true)
+
+    const end = result.pageInfo.endCursor!
+    const decoded = decodeMeshiCursor(end)
+    expect(decoded.id).toBe(2)
+
+    // Second page after endCursor should return the remaining item and hasNextPage=false
+    prismaMock.meshi.findMany.mockResolvedValue([items[2]])
+
+    const result2 = await callResolver(meshis as any, {}, { first: 2, after: end }, ctx)
+    expect(prismaMock.meshi.findMany).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ OR: expect.any(Array) }),
+        orderBy: [ { publishedDate: 'desc' }, { id: 'desc' } ],
+        take: 3,
+      }),
+    )
+    expect(result2.edges.map((e: any) => e.node.id)).toEqual([1])
+    expect(result2.pageInfo.hasNextPage).toBe(false)
+  })
+
+  it('supports tie-breaker: same publishedDate resolves by id', async () => {
+    const items = [
+      { id: 10, title: 'X', imageUrl: '', storeName: '', address: '', siteUrl: '', publishedDate: d('2025-02-10T00:00:00Z'), latitude: 0, longitude: 0, createdAt: d('2025-02-10T00:00:00Z') },
+      { id: 9, title: 'Y', imageUrl: '', storeName: '', address: '', siteUrl: '', publishedDate: d('2025-02-10T00:00:00Z'), latitude: 0, longitude: 0, createdAt: d('2025-02-10T00:00:00Z') },
+    ]
+
+    prismaMock.meshi.count.mockResolvedValue(items.length)
+    prismaMock.meshi.findMany.mockResolvedValue(items)
+
+    const firstPage = await callResolver(meshis as any, {}, { first: 1 }, ctx)
+    expect(firstPage.edges.map((e: any) => e.node.id)).toEqual([10])
+    expect(firstPage.pageInfo.hasNextPage).toBe(true)
+
+    const endCursor = firstPage.pageInfo.endCursor!
+    const { id, publishedDateMs } = decodeMeshiCursor(endCursor)
+    expect(id).toBe(10)
+    expect(publishedDateMs).toBeDefined()
+
+    // Next page should return id 9 (same date, lower id)
+    prismaMock.meshi.findMany.mockResolvedValue([items[1]])
+
+    const secondPage = await callResolver(meshis as any, {}, { first: 1, after: endCursor }, ctx)
+    expect(secondPage.edges.map((e: any) => e.node.id)).toEqual([9])
+    expect(secondPage.pageInfo.hasNextPage).toBe(false)
+  })
+})

--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -5,6 +5,9 @@ import type { MeshiQuery, MeshiQueryVariables } from '@/src/gql/graphql'
 import { GraphQLClient } from 'graphql-request'
 import { cache } from 'react'
 
+// 本ページは常に最新データを取得する（ISRキャッシュ無効化）
+export const dynamic = 'force-dynamic'
+
 export default async function Home() {
   const data = await fetchMeshis(10) // 初期表示を20件に制限
 
@@ -38,8 +41,9 @@ const fetchMeshis = async (first = 20, query?: string) => {
 
   const client = new GraphQLClient(backendEndpoint, {
     // biome-ignore lint/suspicious/noExplicitAny: Next.js fetch cache requires any for generic fetch signature
+    // 初回データ取得時もキャッシュを使用しない（本番でのhasNextPage不整合を回避）
     fetch: cache(async (url: any, params: any) =>
-      fetch(url, { ...params, next: { revalidate: 60 } }),
+      fetch(url, { ...params, cache: 'no-store' }),
     ),
   })
 

--- a/apps/frontend/components/meshi-list-container.tsx
+++ b/apps/frontend/components/meshi-list-container.tsx
@@ -130,7 +130,7 @@ export function MeshiListContainer({
   // Intersection Observer for infinite scroll
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    if (!pageInfo.hasNextPage || isLoadingMore || isPending || isInitialMount) {
+    if (isLoadingMore || isPending || isInitialMount) {
       console.log('🚫 Intersection Observer setup skipped:', {
         hasNextPage: pageInfo.hasNextPage,
         isLoadingMore,


### PR DESCRIPTION
このPRは本番のトップページのメシ一覧で「まだ残っているのに全て表示されました」と表示される問題を修正します。

主な変更
- Frontend
  - Homeを動的レンダリング化（`export const dynamic = 'force-dynamic'`）。
  - 初回GraphQLフェッチを `cache: 'no-store'` に変更し、ISRキャッシュで `hasNextPage=false` が固定化される事象を回避。
  - IntersectionObserverの初期化条件を緩和し、`hasNextPage=false` の誤判定でも再検証の機会を確保。
- Backend
  - ページネーションを並び順と一致させるため、複合カーソル（`publishedDate desc, id desc`）に変更。
  - 旧フォーマット（`meshi:<id>`）との互換を維持。
  - 検索（PGroonga）側も同様の ORDER BY/カーソル条件に対応。
- Tests
  - `meshis` リゾルバのユニットテストを追加し、複合カーソルの hasNextPage 判定とタイブレーク（同一 publishedDate での id 降順）を検証。

影響/確認事項
- 本番でトップページをスクロールし、継続的に読み込みが行われること。
- 末尾でのみ「すべての飯を表示しました 🍚」が表示されること。

フォローアップ（任意）
- 検索APIのユニットテスト追加（必要なら対応します）。
