### PR TITLE
fix(renovate): remove invalid option prConcurrentLimitInMinutes

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
     "rebaseStalePrs": true
   },
   "prConcurrentLimit": 10,
-  "prConcurrentLimitInMinutes": 10,
+  
   "packageRules": [
     {
       "matchUpdateTypes": ["patch"],


### PR DESCRIPTION
Renovate が停止していた原因（#90）を解消するため、無効な設定キー `prConcurrentLimitInMinutes` を削除しました。

変更点
- `renovate.json` から `prConcurrentLimitInMinutes` を削除
- `prConcurrentLimit` はそのまま維持（同時オープンPR上限10）
- その他の挙動変更なし

期待効果
- Renovate の設定検証が通り、PR作成が再開されます
- 必要に応じて `prHourlyLimit` の追加などは別PRで検討可能です

関連: #90
