### PR TITLE
perf(frontend): 初期描画最適化（tw-animate-css削除＋LCP画像priority/sizes付与）

### DIFF
--- a/apps/frontend/app/globals.css
+++ b/apps/frontend/app/globals.css
@@ -1,5 +1,4 @@
 @import "tailwindcss";
-@import "tw-animate-css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/apps/frontend/components/restaurant-detail.tsx
+++ b/apps/frontend/components/restaurant-detail.tsx
@@ -39,6 +39,8 @@ export default async function RestaurantDetail({ id }: Props) {
                   alt="Restaurant Image"
                   fill
                   loading="eager"
+                  priority
+                  sizes="(max-width: 768px) 100vw, 600px"
                 />
               </div>
             </Suspense>

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -50,7 +50,6 @@
     "tailwind-merge": "3.3.1",
     "tailwindcss": "4.1.13",
     "tiny-invariant": "1.3.3",
-    "tw-animate-css": "1.3.8",
     "zustand": "5.0.8"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,9 +205,6 @@ importers:
       tiny-invariant:
         specifier: 1.3.3
         version: 1.3.3
-      tw-animate-css:
-        specifier: 1.3.8
-        version: 1.3.8
       zustand:
         specifier: 5.0.8
         version: 5.0.8(@types/react@19.1.13)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1))
@@ -5548,9 +5545,6 @@ packages:
   turbo@2.5.8:
     resolution: {integrity: sha512-5c9Fdsr9qfpT3hA0EyYSFRZj1dVVsb6KIWubA9JBYZ/9ZEAijgUEae0BBR/Xl/wekt4w65/lYLTFaP3JmwSO8w==}
     hasBin: true
-
-  tw-animate-css@1.3.8:
-    resolution: {integrity: sha512-Qrk3PZ7l7wUcGYhwZloqfkWCmaXZAoqjkdbIDvzfGshwGtexa/DAs9koXxIkrpEasyevandomzCBAV1Yyop5rw==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -12078,8 +12072,6 @@ snapshots:
       turbo-linux-arm64: 2.5.8
       turbo-windows-64: 2.5.8
       turbo-windows-arm64: 2.5.8
-
-  tw-animate-css@1.3.8: {}
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
概要
- 開発ビルドでFCP悪化の一因だったグローバルCSSを整理し、本番初期描画の軽量化を維持しました。
- 本番ビルド（:33001）のSlow 4G + 4x 条件でも FCP/LCP ≈ 0.65s 台を確認。

変更点
- app/globals.css: `@import "tw-animate-css"` を削除（Tailwindコア＋`tailwindcss-animate`で代替）。
- components/restaurant-detail.tsx: メイン画像に `priority` と `sizes="(max-width: 768px) 100vw, 600px"` を付与。
- apps/frontend/package.json: 未使用依存 `tw-animate-css` を削除。

計測（:33001, 本番ビルド）
- /meshi/18: FCP ≈ 668 ms, LCP ≈ 666 ms（Slow 4G + 4x）, CLS 0.00
- /meshi/15: FCP ≈ 648 ms, LCP ≈ 645 ms（Slow 4G + 4x）, CLS 0.00

リスク/互換性
- `tw-animate-css` 固有ユーティリティの利用なしを全コード検索で確認。UI崩れの可能性は低い想定。

チェックリスト
- [ ] `pnpm format`
- [ ] `pnpm lint`
- [ ] 主要ページのE2Eスタイル崩れ確認

