### PR TITLE
fix(renovate): ローカルプリセット参照を修正

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "local>./.github/renovate/presets/checklist.json"
+    "local>presets/checklist"
   ],
   "timezone": "Asia/Tokyo",
   "labels": ["renovate"],


### PR DESCRIPTION
## 概要
- Renovate のローカルプリセット参照を `local>presets/checklist` に更新しました。
- `local>./.github/renovate/presets/checklist.json` 参照エラーを解消します。

## 動作確認
- `pnpm dlx renovate renovate-config-validator`（GitHub Token 未設定のため失敗）
