### PR TITLE
fix(frontend): 検索ページのデザイン統一とクエリリセット機能を修正

### DIFF
--- a/apps/frontend/app/search/page.tsx
+++ b/apps/frontend/app/search/page.tsx
@@ -1,24 +1,97 @@
-import GlobalSearch from '@/components/global-search'
+import { loadMoreMeshis } from '@/app/actions/meshi'
+import { MeshiListContainer } from '@/components/meshi-list-container'
+import { SearchInput } from '@/components/search-input'
+import { graphql } from '@/src/gql'
+import type { MeshiQuery, MeshiQueryVariables } from '@/src/gql/graphql'
+import { GraphQLClient } from 'graphql-request'
+import { cache } from 'react'
 
-/**
- * Home Page Component
- * Renders the main page of the Global Search UI Demo
- */
-export default function Home() {
+// 本ページは常に最新データを取得する（ISRキャッシュ無効化）
+export const dynamic = 'force-dynamic'
+
+type SearchPageProps = {
+  searchParams: Promise<{ q?: string }>
+}
+
+export default async function SearchPage(props: SearchPageProps) {
+  const searchParams = await props.searchParams
+  const query = searchParams.q
+
+  const data = await fetchMeshis(10, query) // 初期表示を10件に制限
+
   return (
-    <main className="flex h-full w-full flex-col items-center justify-center gap-6 p-8">
-      <header className="flex flex-col items-center justify-center gap-2 text-center">
-        <h1 className="text-2xl font-bold">調べるぞ🐤</h1>
-      </header>
-
-      <section
-        className="flex w-full items-start justify-center"
-        aria-label="Global Search"
-      >
-        <div className="flex w-full max-w-[750px] items-start justify-center rounded-md border border-stone-200 bg-gradient-to-r from-stone-100 to-stone-50 p-2">
-          <GlobalSearch />
+    <div className="flex justify-center">
+      <div className="flex flex-col gap-2 md:p-20 px-2 pt-6 max-w-[900px]">
+        <div className="text-center mb-4 md:mb-8">
+          <h1 className="text-4xl md:text-5xl font-bold text-center mb-2 text-primary">
+            調べるぞ🐤
+          </h1>
+          <p className="text-gray-600">美味しいごはんを検索しよう！</p>
         </div>
-      </section>
-    </main>
+
+        {/* 検索入力 */}
+        <div className="mb-6">
+          <SearchInput initialQuery={query} />
+        </div>
+
+        {/* 検索結果 */}
+        {query && (
+          <div className="mb-4 text-gray-600">
+            <span className="font-semibold">「{query}」</span>の検索結果：{' '}
+            {data.meshis.totalCount}件
+          </div>
+        )}
+
+        <MeshiListContainer
+          key={query || 'all'}
+          initialData={data}
+          loadMoreAction={loadMoreMeshis}
+          query={query}
+        />
+      </div>
+    </div>
   )
 }
+
+/**
+ * メシデータを取得する関数
+ * @param first 取得する件数（デフォルト20件）
+ * @param query 検索クエリ（オプション）
+ * @returns メシデータ
+ */
+const fetchMeshis = async (first = 20, query?: string) => {
+  const backendEndpoint =
+    process.env.BACKEND_ENDPOINT ?? 'http://localhost:44000/graphql'
+
+  const client = new GraphQLClient(backendEndpoint, {
+    // biome-ignore lint/suspicious/noExplicitAny: Next.js fetch cache requires any for generic fetch signature
+    // 初回データ取得時もキャッシュを使用しない（本番でのhasNextPage不整合を回避）
+    fetch: cache(async (url: any, params: any) =>
+      fetch(url, { ...params, cache: 'no-store' }),
+    ),
+  })
+
+  // 変数オブジェクトを明示的に型付け
+  const variables: MeshiQueryVariables = { first, query }
+
+  const data = await client.request<MeshiQuery>(MeshiQueryDocument, variables)
+  return data
+}
+
+const MeshiQueryDocument = graphql(/* GraphQL */ `
+  query Meshi($first: Int = 20, $after: String, $query: String) {
+    meshis(first: $first, after: $after, query: $query) {
+      edges {
+        node {
+          id
+          ...MeshiCard
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+    }
+  }
+`)

--- a/apps/frontend/components/search-input.tsx
+++ b/apps/frontend/components/search-input.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { useDebounce } from '@uidotdev/usehooks'
+import { Search, X } from 'lucide-react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+type SearchInputProps = {
+  initialQuery?: string
+}
+
+/**
+ * SearchInput component for search page
+ * Updates URL query parameter when user types
+ */
+export function SearchInput({ initialQuery = '' }: SearchInputProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [searchTerm, setSearchTerm] = useState(initialQuery)
+
+  const debouncedSearchTerm = useDebounce(searchTerm, 500)
+
+  // Update URL when debounced search term changes
+  useEffect(() => {
+    const params = new URLSearchParams(searchParams.toString())
+
+    if (debouncedSearchTerm) {
+      params.set('q', debouncedSearchTerm)
+    } else {
+      params.delete('q')
+    }
+
+    const newUrl = debouncedSearchTerm ? `/search?${params.toString()}` : '/search'
+    router.push(newUrl)
+  }, [debouncedSearchTerm, router, searchParams])
+
+  const handleClear = () => {
+    setSearchTerm('')
+  }
+
+  return (
+    <div className="relative w-full">
+      <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+      <Input
+        type="text"
+        placeholder="お店の名前や料理を検索..."
+        value={searchTerm}
+        onChange={(e) => setSearchTerm(e.target.value)}
+        className="w-full pl-10 pr-10"
+        aria-label="Search restaurants"
+      />
+      {searchTerm && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="absolute right-1 top-1/2 h-8 w-8 -translate-y-1/2"
+          onClick={handleClear}
+          aria-label="Clear search"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- 🎨 検索ページのデザインをトップページと統一（タイトル、レイアウト、カードグリッド）
- 📊 初期表示件数を10件に制限し、スクロールでページネーションを実装
- 🐛 検索クエリ変更時に前の検索結果が残るバグを修正（`MeshiListContainer`に`key`プロップ追加）
- ✨ `SearchInput`コンポーネントを新規作成（デバウンス機能、URLクエリパラメータ連携）
- 🔢 検索結果件数の表示を追加

## 修正したバグ

検索クエリを変更した際に、前の検索結果が残ったまま新しい結果が追加されてしまう問題を修正しました。

**原因**: `MeshiListContainer`コンポーネントの`useState`は初回マウント時にのみ初期化されるため、新しい`initialData`が渡されても状態がリセットされませんでした。

**解決策**: `MeshiListContainer`に`key={query || 'all'}`を追加し、検索クエリが変更されるとコンポーネントが再マウントされるようにしました。

## Test plan

- [ ] `/search`ページにアクセスし、デザインがトップページと統一されていることを確認
- [ ] 検索ボックスに「ラーメン」と入力し、検索結果が表示されることを確認
- [ ] スクロールして、追加のデータが読み込まれることを確認（無限スクロール）
- [ ] 検索語を「カレー」に変更し、ラーメンの結果が消えてカレーの結果のみが表示されることを確認
- [ ] 検索ボックスをクリアし、全件表示に戻ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)