### PR TITLE
検索入力の背景をprimary色ベースに変更

### DIFF
--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -46,7 +46,7 @@ export default async function Home(props: HomePageProps) {
       </div>
 
       {/* 検索入力（画面下部固定） */}
-      <div className="fixed bottom-4 left-4 right-4 bg-white rounded-2xl shadow-2xl z-50 p-4 md:bottom-6 md:left-6 md:right-6">
+      <div className="fixed bottom-4 left-4 right-4 bg-primary/20 backdrop-blur-sm rounded-2xl shadow-2xl z-50 p-4 md:bottom-6 md:left-6 md:right-6">
         <div className="max-w-[900px] mx-auto">
           <SearchInput initialQuery={query} />
         </div>


### PR DESCRIPTION
## Summary
- 検索入力の背景をprimary色ベースに変更してページ背景との視覚的な分離を改善

## 変更内容
### 変更
- `bg-primary/20` - primary色を20%の透明度で背景に適用
- `backdrop-blur-sm` - 控えめなぼかしエフェクトを追加

### 背景
- iPhoneでの確認で、白背景(`bg-white`)だとページ全体の背景と同化して使いづらかった
- primary色を薄くした背景にすることで、視認性を向上

## Test plan
- [ ] iPhoneで検索入力の背景がページ背景と明確に区別できることを確認
- [ ] primary色が薄く適用され、浮遊感のあるデザインになっていることを確認
- [ ] ぼかしエフェクトが控えめで、入力テキストの視認性が保たれていることを確認
- [ ] デスクトップ・モバイル両方で適切に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)