### PR TITLE
chore(ci): ageage収集後のVercel再デプロイを削除

### DIFF
--- a/.github/workflows/exec-ageage-collector.yml
+++ b/.github/workflows/exec-ageage-collector.yml
@@ -19,7 +19,6 @@ env:
   IMAGE_HOST: "asia-northeast1-docker.pkg.dev"
   IMAGE_TAG_BASE: ${{ secrets.IMAGE_TAG_BASE }} # 例. プロジェクトID/artifact_registry名/イメージ名
   GCP_REGION: asia-northeast1
-  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
 jobs:
   exec-ageage-collector:
@@ -57,33 +56,3 @@ jobs:
           echo ": $jobs_cmd a job"
           gcloud run jobs $jobs_cmd ageagecli --image="${{ env.IMAGE_HOST }}/${{ env.IMAGE_TAG_BASE }}:latest" --max-retries=1 --args="node,dist/src/scripts/ageage-collector/index.js" --service-account="${{ env.RUN_SERVICE_ACCOUNT }}" --set-secrets="DATABASE_URL=DATABASE_URL:latest"
           gcloud run jobs execute ageagecli --wait --format=json
-
-  vercle-deploy:
-    needs: exec-ageage-collector
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          check-latest: true
-
-      - name: Setup pnpm (latest)
-        uses: pnpm/action-setup@v2
-        with:
-          version: latest
-          run_install: false  # 自動で pnpm install したくない場合は false
-
-      - name: Install Vercel CLI
-        run: npm install --global vercel@latest
-
-      - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=production --token=${{ env.VERCEL_TOKEN }}
-
-      - name: Build Project Artifacts
-        run: vercel build --prod --token=${{ env.VERCEL_TOKEN }}
-
-      - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt --prod --token=${{ env.VERCEL_TOKEN }}


### PR DESCRIPTION
## 概要
- Exec Ageage Collector workflow から後続の Vercel 再デプロイジョブを削除
- 不要になった workflow env の VERCEL_TOKEN 参照を削除

## 背景
- ageage collector は Cloud Run Job でDBを更新する処理で、frontendは実行時にbackend GraphQLからデータ取得している
- トップページと追加読み込みは no-store、/api/meshi も60秒revalidateのため、collector後の再デプロイは不要
- Vercel token失効で collector workflow 全体が failure 扱いになる問題を避ける

## 確認
- yq で workflow YAML として読めることを確認
- 残る job が exec-ageage-collector のみであることを確認