### PR TITLE
feat(frontend): 店舗詳細ページの情報設計とレイアウトを改善

### DIFF
--- a/apps/frontend/components/restaurant-detail.tsx
+++ b/apps/frontend/components/restaurant-detail.tsx
@@ -1,10 +1,20 @@
-import { ArrowLeft, Globe, MapPin } from 'lucide-react'
+import {
+  ArrowLeft,
+  CalendarDays,
+  ChevronRight,
+  ExternalLink,
+  Info,
+  MapPin,
+  MapPinned,
+  Store,
+  UtensilsCrossed,
+} from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { cache } from 'react'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { createRevalidatedGraphQLClient } from '@/lib/graphql-client'
 import { graphql } from '@/src/gql'
 
@@ -22,6 +32,13 @@ export default async function RestaurantDetail({ id }: Props) {
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://meshipiyo.app'
   const canonicalUrl = `${siteUrl}/meshi/${meshi.id}`
   const mapQuery = encodeURIComponent(`${meshi.storeName} ${meshi.address}`)
+  const mapUrl = `https://www.google.com/maps/search/?api=1&query=${mapQuery}`
+  const publishedDate = new Date(meshi.publishedDate)
+  const publishedDateLabel = new Intl.DateTimeFormat('ja-JP', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(publishedDate)
   const restaurantJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'Restaurant',
@@ -66,7 +83,7 @@ export default async function RestaurantDetail({ id }: Props) {
   }
 
   return (
-    <div className="flex flex-col items-center container mx-auto px-4 py-8">
+    <main className="min-h-screen bg-[linear-gradient(180deg,#fffaf0_0%,#ffffff_28rem)]">
       <script
         type="application/ld+json"
         // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD is serialized from trusted API fields and escapes HTML delimiters
@@ -81,79 +98,213 @@ export default async function RestaurantDetail({ id }: Props) {
           __html: JSON.stringify(breadcrumbJsonLd).replace(/</g, '\\u003c'),
         }}
       />
-      <Link href="/" passHref className="w-full">
-        <Button variant="ghost" className="mb-4">
-          <ArrowLeft className="mr-2 size-4" />
-          戻る
-        </Button>
-      </Link>
-      <div className="grid grid-cols-1 gap-8 max-w-[600px]">
-        <div>
-          {meshi.imageUrl ? (
-            <div className="relative h-[400px] w-full">
-              <Image
-                className="rounded-lg object-cover"
-                src={meshi.imageUrl}
-                alt={`${meshi.storeName}の料理`}
-                fill
-                priority
-                sizes="(max-width: 768px) 100vw, 600px"
-              />
-            </div>
-          ) : (
-            <div className="flex items-center justify-center h-[400px] bg-muted rounded-lg">
-              <p className="text-muted-foreground">画像がありません</p>
-            </div>
-          )}
-        </div>
-        <div>
-          <h1 className="text-3xl font-bold mb-2 text-balance">
-            {meshi.storeName}
-          </h1>
+
+      <div className="mx-auto w-full max-w-6xl px-4 py-5 sm:px-6 sm:py-8 lg:px-8">
+        <nav
+          aria-label="パンくずリスト"
+          className="mb-5 flex min-w-0 items-center gap-1 text-sm text-muted-foreground"
+        >
+          <Link href="/" className="shrink-0 hover:text-foreground">
+            ホーム
+          </Link>
+          <ChevronRight aria-hidden="true" className="size-4 shrink-0" />
           {meshi.municipality && (
-            <div className="flex flex-row flex-wrap gap-1 mb-2">
+            <>
               <Link
                 href={`/municipality/${meshi.municipality.id}`}
-                className="px-4 py-1 rounded-xl font-bold text-l text-white w-fit bg-primary"
+                className="shrink-0 hover:text-foreground"
               >
                 {meshi.municipality.name}
               </Link>
-            </div>
+              <ChevronRight aria-hidden="true" className="size-4 shrink-0" />
+            </>
           )}
-          <p className="text-lg text-muted-foreground mb-4 text-pretty">
-            {meshi.title}
-          </p>
-          <div className="space-y-4">
-            <Link
-              href={`https://www.google.com/maps/search/?api=1&query=${mapQuery}`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Card>
-                <CardContent className="flex items-center p-4">
-                  <MapPin className="mr-2 size-5" />
-                  <span>{meshi.address}</span>
-                </CardContent>
-              </Card>
-            </Link>
-          </div>
-          <div className="mt-6 flex flex-wrap gap-4">
-            {meshi.siteUrl && (
-              <Link
-                href={meshi.siteUrl}
-                target="_blank"
-                rel="noopener noreferrer external"
-              >
-                <Button>
-                  <Globe className="mr-2 size-4" />
-                  紹介記事を読む
+          <span className="truncate text-foreground" aria-current="page">
+            {meshi.storeName}
+          </span>
+        </nav>
+
+        <Button asChild variant="ghost" className="mb-4 -ml-4">
+          <Link href="/">
+            <ArrowLeft aria-hidden="true" className="mr-2 size-4" />
+            一覧へ戻る
+          </Link>
+        </Button>
+
+        <article>
+          <div className="grid items-start gap-8 lg:grid-cols-[minmax(0,1.15fr)_minmax(22rem,0.85fr)] lg:gap-12">
+            <figure className="min-w-0">
+              {meshi.imageUrl ? (
+                <div className="relative aspect-[4/3] w-full overflow-hidden rounded-3xl bg-muted shadow-[0_24px_70px_-35px_rgba(68,43,15,0.45)]">
+                  <Image
+                    className="object-cover"
+                    src={meshi.imageUrl}
+                    alt={`${meshi.storeName}の料理`}
+                    fill
+                    priority
+                    sizes="(max-width: 1024px) 100vw, 650px"
+                  />
+                </div>
+              ) : (
+                <div className="flex aspect-[4/3] items-center justify-center rounded-3xl bg-muted">
+                  <p className="text-muted-foreground">画像がありません</p>
+                </div>
+              )}
+              <figcaption className="mt-3 text-xs text-muted-foreground">
+                紹介記事に掲載されたイメージ
+              </figcaption>
+            </figure>
+
+            <div className="min-w-0 lg:pt-3">
+              <div className="mb-4 flex flex-wrap items-center gap-2">
+                <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-3 py-1 text-xs font-bold text-amber-950">
+                  <UtensilsCrossed aria-hidden="true" className="size-3.5" />
+                  沖縄グルメ
+                </span>
+                {meshi.municipality && (
+                  <Link
+                    href={`/municipality/${meshi.municipality.id}`}
+                    className="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-white px-3 py-1 text-xs font-bold text-amber-950 transition-colors hover:bg-amber-50"
+                  >
+                    <MapPin aria-hidden="true" className="size-3.5" />
+                    {meshi.municipality.name}
+                  </Link>
+                )}
+              </div>
+
+              <h1 className="text-balance text-3xl font-bold tracking-tight text-foreground sm:text-4xl lg:text-5xl lg:leading-[1.15]">
+                {meshi.storeName}
+              </h1>
+              <p className="mt-5 text-pretty text-lg leading-8 text-muted-foreground">
+                {meshi.title}
+              </p>
+
+              <div className="mt-7 grid gap-3 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
+                <Button asChild size="lg" className="h-12 rounded-xl">
+                  <Link href={mapUrl} target="_blank" rel="noopener noreferrer">
+                    <MapPinned aria-hidden="true" className="mr-2 size-5" />
+                    地図で場所を見る
+                  </Link>
                 </Button>
-              </Link>
-            )}
+                {meshi.siteUrl && (
+                  <Button
+                    asChild
+                    variant="outline"
+                    size="lg"
+                    className="h-12 rounded-xl bg-white"
+                  >
+                    <Link
+                      href={meshi.siteUrl}
+                      target="_blank"
+                      rel="noopener noreferrer external"
+                    >
+                      <ExternalLink
+                        aria-hidden="true"
+                        className="mr-2 size-5"
+                      />
+                      紹介記事を読む
+                    </Link>
+                  </Button>
+                )}
+              </div>
+
+              <p className="mt-4 flex items-start gap-2 text-xs leading-5 text-muted-foreground">
+                <Info aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
+                営業時間・定休日・提供状況は変更される場合があります。訪問前に紹介記事や店舗の最新情報をご確認ください。
+              </p>
+            </div>
           </div>
-        </div>
+
+          <div className="mt-10 grid gap-6 lg:mt-14 lg:grid-cols-[minmax(0,1.35fr)_minmax(18rem,0.65fr)]">
+            <Card className="overflow-hidden border-amber-100 shadow-none">
+              <CardHeader className="border-b border-amber-100 bg-amber-50/60">
+                <h2 className="flex items-center gap-2 text-lg font-semibold">
+                  <Store aria-hidden="true" className="size-5 text-amber-800" />
+                  店舗情報
+                </h2>
+              </CardHeader>
+              <CardContent className="p-0">
+                <dl className="divide-y divide-border">
+                  <div className="grid gap-1 px-5 py-4 sm:grid-cols-[7rem_1fr] sm:gap-4">
+                    <dt className="text-sm font-medium text-muted-foreground">
+                      所在地
+                    </dt>
+                    <dd className="text-sm leading-6">{meshi.address}</dd>
+                  </div>
+                  {meshi.municipality && (
+                    <div className="grid gap-1 px-5 py-4 sm:grid-cols-[7rem_1fr] sm:gap-4">
+                      <dt className="text-sm font-medium text-muted-foreground">
+                        エリア
+                      </dt>
+                      <dd className="text-sm">
+                        <Link
+                          href={`/municipality/${meshi.municipality.id}`}
+                          className="font-medium text-amber-800 underline decoration-amber-300 underline-offset-4 hover:text-amber-950"
+                        >
+                          {meshi.municipality.name}のグルメを見る
+                        </Link>
+                      </dd>
+                    </div>
+                  )}
+                  <div className="grid gap-1 px-5 py-4 sm:grid-cols-[7rem_1fr] sm:gap-4">
+                    <dt className="text-sm font-medium text-muted-foreground">
+                      紹介日
+                    </dt>
+                    <dd className="flex items-center gap-2 text-sm">
+                      <CalendarDays
+                        aria-hidden="true"
+                        className="size-4 text-amber-800"
+                      />
+                      <time dateTime={publishedDate.toISOString()}>
+                        {publishedDateLabel}
+                      </time>
+                    </dd>
+                  </div>
+                </dl>
+              </CardContent>
+            </Card>
+
+            <aside className="rounded-2xl bg-stone-900 p-6 text-stone-50">
+              <p className="text-xs font-bold tracking-[0.18em] text-amber-300">
+                BEFORE YOU GO
+              </p>
+              <h2 className="mt-3 text-xl font-bold">訪れる前に</h2>
+              <p className="mt-3 text-sm leading-7 text-stone-300">
+                飯ぴよでは、紹介記事から店舗名・住所・掲載日を整理しています。メニューの提供状況や営業情報は、掲載元の最新情報をご確認ください。
+              </p>
+              <div className="mt-5 grid gap-2">
+                <Button
+                  asChild
+                  variant="secondary"
+                  className="w-full justify-between rounded-xl"
+                >
+                  <Link href={mapUrl} target="_blank" rel="noopener noreferrer">
+                    経路を確認する
+                    <ExternalLink aria-hidden="true" className="size-4" />
+                  </Link>
+                </Button>
+                {meshi.siteUrl && (
+                  <Button
+                    asChild
+                    variant="ghost"
+                    className="w-full justify-between rounded-xl text-stone-100 hover:bg-white/10 hover:text-white"
+                  >
+                    <Link
+                      href={meshi.siteUrl}
+                      target="_blank"
+                      rel="noopener noreferrer external"
+                    >
+                      掲載元で詳細を確認
+                      <ExternalLink aria-hidden="true" className="size-4" />
+                    </Link>
+                  </Button>
+                )}
+              </div>
+            </aside>
+          </div>
+        </article>
       </div>
-    </div>
+    </main>
   )
 }
 

--- a/apps/frontend/components/restaurant-detail.tsx
+++ b/apps/frontend/components/restaurant-detail.tsx
@@ -1,20 +1,16 @@
 import {
-  ArrowLeft,
   CalendarDays,
   ChevronRight,
   ExternalLink,
   Info,
   MapPin,
-  MapPinned,
   Store,
-  UtensilsCrossed,
 } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { cache } from 'react'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { createRevalidatedGraphQLClient } from '@/lib/graphql-client'
 import { graphql } from '@/src/gql'
 
@@ -83,7 +79,7 @@ export default async function RestaurantDetail({ id }: Props) {
   }
 
   return (
-    <main className="min-h-screen bg-[linear-gradient(180deg,#fffaf0_0%,#ffffff_28rem)]">
+    <main className="min-h-screen bg-background">
       <script
         type="application/ld+json"
         // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD is serialized from trusted API fields and escapes HTML delimiters
@@ -99,10 +95,10 @@ export default async function RestaurantDetail({ id }: Props) {
         }}
       />
 
-      <div className="mx-auto w-full max-w-6xl px-4 py-5 sm:px-6 sm:py-8 lg:px-8">
+      <div className="mx-auto w-full max-w-[900px] px-4 py-6 sm:px-6 sm:py-10">
         <nav
           aria-label="パンくずリスト"
-          className="mb-5 flex min-w-0 items-center gap-1 text-sm text-muted-foreground"
+          className="mb-6 flex min-w-0 items-center gap-1 text-sm text-muted-foreground"
         >
           <Link href="/" className="shrink-0 hover:text-foreground">
             ホーム
@@ -124,66 +120,54 @@ export default async function RestaurantDetail({ id }: Props) {
           </span>
         </nav>
 
-        <Button asChild variant="ghost" className="mb-4 -ml-4">
-          <Link href="/">
-            <ArrowLeft aria-hidden="true" className="mr-2 size-4" />
-            一覧へ戻る
-          </Link>
-        </Button>
-
         <article>
-          <div className="grid items-start gap-8 lg:grid-cols-[minmax(0,1.15fr)_minmax(22rem,0.85fr)] lg:gap-12">
-            <figure className="min-w-0">
+          <div className="grid items-start gap-7 md:grid-cols-[minmax(0,1.05fr)_minmax(18rem,0.95fr)] md:gap-10">
+            <div className="min-w-0">
               {meshi.imageUrl ? (
-                <div className="relative aspect-[4/3] w-full overflow-hidden rounded-3xl bg-muted shadow-[0_24px_70px_-35px_rgba(68,43,15,0.45)]">
+                <div className="relative aspect-[4/3] w-full overflow-hidden rounded-lg bg-muted shadow-[0_8px_28px_rgba(0,0,0,0.07)]">
                   <Image
                     className="object-cover"
                     src={meshi.imageUrl}
                     alt={`${meshi.storeName}の料理`}
                     fill
                     priority
-                    sizes="(max-width: 1024px) 100vw, 650px"
+                    sizes="(max-width: 768px) 100vw, 480px"
                   />
                 </div>
               ) : (
-                <div className="flex aspect-[4/3] items-center justify-center rounded-3xl bg-muted">
+                <div className="flex aspect-[4/3] items-center justify-center rounded-lg bg-muted">
                   <p className="text-muted-foreground">画像がありません</p>
                 </div>
               )}
-              <figcaption className="mt-3 text-xs text-muted-foreground">
-                紹介記事に掲載されたイメージ
-              </figcaption>
-            </figure>
+            </div>
 
-            <div className="min-w-0 lg:pt-3">
-              <div className="mb-4 flex flex-wrap items-center gap-2">
-                <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-3 py-1 text-xs font-bold text-amber-950">
-                  <UtensilsCrossed aria-hidden="true" className="size-3.5" />
-                  沖縄グルメ
-                </span>
-                {meshi.municipality && (
-                  <Link
-                    href={`/municipality/${meshi.municipality.id}`}
-                    className="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-white px-3 py-1 text-xs font-bold text-amber-950 transition-colors hover:bg-amber-50"
-                  >
-                    <MapPin aria-hidden="true" className="size-3.5" />
-                    {meshi.municipality.name}
-                  </Link>
-                )}
-              </div>
+            <div className="min-w-0 md:pt-2">
+              {meshi.municipality && (
+                <Link
+                  href={`/municipality/${meshi.municipality.id}`}
+                  className="mb-3 inline-flex items-center gap-1.5 rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/15"
+                >
+                  <MapPin aria-hidden="true" className="size-3.5" />
+                  {meshi.municipality.name}
+                </Link>
+              )}
 
-              <h1 className="text-balance text-3xl font-bold tracking-tight text-foreground sm:text-4xl lg:text-5xl lg:leading-[1.15]">
+              <h1 className="text-balance text-3xl font-bold leading-tight tracking-tight text-foreground sm:text-4xl">
                 {meshi.storeName}
               </h1>
-              <p className="mt-5 text-pretty text-lg leading-8 text-muted-foreground">
+              <p className="mt-4 text-pretty leading-7 text-muted-foreground">
                 {meshi.title}
               </p>
 
-              <div className="mt-7 grid gap-3 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
-                <Button asChild size="lg" className="h-12 rounded-xl">
+              <div className="mt-6 grid gap-3 sm:grid-cols-2 md:grid-cols-1 lg:grid-cols-2">
+                <Button
+                  asChild
+                  size="lg"
+                  className="bg-[#665238] text-white hover:bg-[#58462f] hover:opacity-100"
+                >
                   <Link href={mapUrl} target="_blank" rel="noopener noreferrer">
-                    <MapPinned aria-hidden="true" className="mr-2 size-5" />
-                    地図で場所を見る
+                    <MapPin aria-hidden="true" className="mr-2 size-4" />
+                    地図を見る
                   </Link>
                 </Button>
                 {meshi.siteUrl && (
@@ -191,7 +175,7 @@ export default async function RestaurantDetail({ id }: Props) {
                     asChild
                     variant="outline"
                     size="lg"
-                    className="h-12 rounded-xl bg-white"
+                    className="bg-background"
                   >
                     <Link
                       href={meshi.siteUrl}
@@ -200,108 +184,64 @@ export default async function RestaurantDetail({ id }: Props) {
                     >
                       <ExternalLink
                         aria-hidden="true"
-                        className="mr-2 size-5"
+                        className="mr-2 size-4"
                       />
                       紹介記事を読む
                     </Link>
                   </Button>
                 )}
               </div>
-
-              <p className="mt-4 flex items-start gap-2 text-xs leading-5 text-muted-foreground">
-                <Info aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
-                営業時間・定休日・提供状況は変更される場合があります。訪問前に紹介記事や店舗の最新情報をご確認ください。
-              </p>
             </div>
           </div>
 
-          <div className="mt-10 grid gap-6 lg:mt-14 lg:grid-cols-[minmax(0,1.35fr)_minmax(18rem,0.65fr)]">
-            <Card className="overflow-hidden border-amber-100 shadow-none">
-              <CardHeader className="border-b border-amber-100 bg-amber-50/60">
-                <h2 className="flex items-center gap-2 text-lg font-semibold">
-                  <Store aria-hidden="true" className="size-5 text-amber-800" />
-                  店舗情報
-                </h2>
-              </CardHeader>
-              <CardContent className="p-0">
-                <dl className="divide-y divide-border">
-                  <div className="grid gap-1 px-5 py-4 sm:grid-cols-[7rem_1fr] sm:gap-4">
-                    <dt className="text-sm font-medium text-muted-foreground">
-                      所在地
-                    </dt>
-                    <dd className="text-sm leading-6">{meshi.address}</dd>
-                  </div>
-                  {meshi.municipality && (
-                    <div className="grid gap-1 px-5 py-4 sm:grid-cols-[7rem_1fr] sm:gap-4">
-                      <dt className="text-sm font-medium text-muted-foreground">
-                        エリア
-                      </dt>
-                      <dd className="text-sm">
-                        <Link
-                          href={`/municipality/${meshi.municipality.id}`}
-                          className="font-medium text-amber-800 underline decoration-amber-300 underline-offset-4 hover:text-amber-950"
-                        >
-                          {meshi.municipality.name}のグルメを見る
-                        </Link>
-                      </dd>
-                    </div>
-                  )}
-                  <div className="grid gap-1 px-5 py-4 sm:grid-cols-[7rem_1fr] sm:gap-4">
-                    <dt className="text-sm font-medium text-muted-foreground">
-                      紹介日
-                    </dt>
-                    <dd className="flex items-center gap-2 text-sm">
-                      <CalendarDays
-                        aria-hidden="true"
-                        className="size-4 text-amber-800"
-                      />
-                      <time dateTime={publishedDate.toISOString()}>
-                        {publishedDateLabel}
-                      </time>
-                    </dd>
-                  </div>
-                </dl>
-              </CardContent>
-            </Card>
-
-            <aside className="rounded-2xl bg-stone-900 p-6 text-stone-50">
-              <p className="text-xs font-bold tracking-[0.18em] text-amber-300">
-                BEFORE YOU GO
-              </p>
-              <h2 className="mt-3 text-xl font-bold">訪れる前に</h2>
-              <p className="mt-3 text-sm leading-7 text-stone-300">
-                飯ぴよでは、紹介記事から店舗名・住所・掲載日を整理しています。メニューの提供状況や営業情報は、掲載元の最新情報をご確認ください。
-              </p>
-              <div className="mt-5 grid gap-2">
-                <Button
-                  asChild
-                  variant="secondary"
-                  className="w-full justify-between rounded-xl"
-                >
-                  <Link href={mapUrl} target="_blank" rel="noopener noreferrer">
-                    経路を確認する
-                    <ExternalLink aria-hidden="true" className="size-4" />
-                  </Link>
-                </Button>
-                {meshi.siteUrl && (
-                  <Button
-                    asChild
-                    variant="ghost"
-                    className="w-full justify-between rounded-xl text-stone-100 hover:bg-white/10 hover:text-white"
-                  >
-                    <Link
-                      href={meshi.siteUrl}
-                      target="_blank"
-                      rel="noopener noreferrer external"
-                    >
-                      掲載元で詳細を確認
-                      <ExternalLink aria-hidden="true" className="size-4" />
-                    </Link>
-                  </Button>
-                )}
+          <section className="mt-10 border-t pt-8 sm:mt-12 sm:pt-10">
+            <h2 className="flex items-center gap-2 text-lg font-bold">
+              <Store aria-hidden="true" className="size-5 text-primary" />
+              店舗情報
+            </h2>
+            <dl className="mt-5 divide-y rounded-lg border bg-card px-5 shadow-[0_4px_18px_rgba(0,0,0,0.04)] sm:px-6">
+              <div className="grid gap-1 py-4 sm:grid-cols-[7rem_1fr] sm:gap-4">
+                <dt className="text-sm font-medium text-muted-foreground">
+                  所在地
+                </dt>
+                <dd className="text-sm leading-6">{meshi.address}</dd>
               </div>
-            </aside>
-          </div>
+              {meshi.municipality && (
+                <div className="grid gap-1 py-4 sm:grid-cols-[7rem_1fr] sm:gap-4">
+                  <dt className="text-sm font-medium text-muted-foreground">
+                    エリア
+                  </dt>
+                  <dd className="text-sm">
+                    <Link
+                      href={`/municipality/${meshi.municipality.id}`}
+                      className="font-medium text-primary underline-offset-4 hover:underline"
+                    >
+                      {meshi.municipality.name}
+                    </Link>
+                  </dd>
+                </div>
+              )}
+              <div className="grid gap-1 py-4 sm:grid-cols-[7rem_1fr] sm:gap-4">
+                <dt className="text-sm font-medium text-muted-foreground">
+                  紹介日
+                </dt>
+                <dd className="flex items-center gap-2 text-sm">
+                  <CalendarDays
+                    aria-hidden="true"
+                    className="size-4 text-primary"
+                  />
+                  <time dateTime={publishedDate.toISOString()}>
+                    {publishedDateLabel}
+                  </time>
+                </dd>
+              </div>
+            </dl>
+
+            <p className="mt-4 flex items-start gap-2 rounded-lg bg-muted/70 px-4 py-3 text-xs leading-5 text-muted-foreground">
+              <Info aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
+              営業時間・定休日・提供状況は変更される場合があります。訪問前に掲載元や店舗の最新情報をご確認ください。
+            </p>
+          </section>
         </article>
       </div>
     </main>


### PR DESCRIPTION
## 概要

店舗詳細ページの情報設計とレイアウトを見直しました。

## 変更内容

- 店名・紹介文・画像を中心としたレスポンシブなヒーロー領域へ変更
- Google マップと掲載元記事への導線を明確化
- 所在地・エリア・紹介日を店舗情報として整理
- 市町村ページへの内部リンクと画面上のパンくずを追加
- 訪問前に最新の営業情報を確認する案内を追加
- スマートフォンとデスクトップの双方で読みやすいレイアウトへ調整

## 背景

従来の詳細ページは情報の優先順位が弱く、ユーザーが店舗の場所や掲載元の詳細情報へ移動しづらい状態でした。現行DBで保持している店舗名、住所、画像、紹介タイトル、掲載元URL、掲載日、市町村を活用し、来店判断につながる情報を整理しています。

営業時間・定休日・価格・メニューなど、DBに存在しない情報は推測して表示せず、掲載元や店舗の最新情報を確認するよう案内しています。

## ユーザーへの影響

- 店舗の概要と所在地を短時間で把握できます
- 地図や掲載元記事へ迷わず移動できます
- 市町村別の関連店舗を探しやすくなります
- 古い営業情報による誤案内を避けられます

## 検証

- `pnpm --filter frontend typecheck`
- `pnpm --filter frontend exec biome ci components/restaurant-detail.tsx`
- `pnpm --filter frontend build`
- `git diff --check`
