### PR TITLE
style(frontend): トップページをエディトリアル調に刷新

### DIFF
--- a/apps/frontend/app/municipality/[id]/page.tsx
+++ b/apps/frontend/app/municipality/[id]/page.tsx
@@ -1,4 +1,6 @@
+import { ChevronRight, MapPin } from 'lucide-react'
 import type { Metadata } from 'next'
+import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { cache } from 'react'
 import { MeshiCard } from '@/components/meshi-card'
@@ -48,30 +50,105 @@ export default async function MunicipalityPage({ params }: Props) {
   }
 
   return (
-    <div className="flex flex-col md:gap-8 gap-2 md:p-20 p-2">
-      <h1 className="text-2xl md:text-3xl font-bold text-textBlack">
-        {data.municipality?.name}
-      </h1>
-      <div className="md:px-4 px-1">
-        <p className="font-bold text-textBlack">
-          {data.municipality?.meshis.length}件
-        </p>
-      </div>
-      <div className="flex justify-center">
-        {data.municipality != null && (
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            {data.municipality?.meshis.map((meshi, i) => {
-              if (meshi == null) {
-                throw new Error('meshi is null')
-              }
-              return (
-                <MeshiCard meshi={meshi} key={meshi.id} isEager={i <= 10} />
-              )
-            })}
+    <main className="min-h-screen bg-[#f5f2eb] text-[#302b26]">
+      <div className="mx-auto w-full max-w-[1180px] px-4 py-5 sm:px-6 sm:py-8 lg:px-8">
+        <nav
+          aria-label="パンくずリスト"
+          className="mb-5 flex min-w-0 items-center gap-1 text-xs text-[#777066] sm:mb-7"
+        >
+          <Link href="/" className="hover:text-[#302b26]">
+            ホーム
+          </Link>
+          <ChevronRight aria-hidden="true" className="size-4" />
+          <span aria-current="page" className="truncate text-[#302b26]">
+            {data.municipality.name}
+          </span>
+        </nav>
+
+        <header className="grid overflow-hidden border border-[#2f2b26] md:grid-cols-[1fr_0.38fr]">
+          <div className="flex min-h-[300px] flex-col justify-between bg-[#24211e] p-7 text-white sm:p-10 md:min-h-[360px] lg:p-12">
+            <div className="flex items-center justify-between text-[10px] font-bold tracking-[0.2em] text-white/55">
+              <span>AREA GUIDE</span>
+              <span>OKINAWA</span>
+            </div>
+            <div className="py-10">
+              <p className="mb-4 flex items-center gap-3 text-sm text-[#d5a843]">
+                <MapPin aria-hidden="true" className="size-4" />
+                沖縄のまちから探す
+              </p>
+              <h1 className="text-balance text-[clamp(3rem,8vw,6rem)] font-bold leading-none tracking-[-0.055em]">
+                {data.municipality.name}
+              </h1>
+            </div>
+            <p className="max-w-lg text-sm leading-7 text-white/65">
+              {data.municipality.name}で紹介された、気になる一軒を見つけよう。
+            </p>
           </div>
-        )}
+
+          <div className="flex min-h-[190px] flex-col justify-between bg-[#fbfaf7] p-7 sm:p-10 md:min-h-[360px] lg:p-12">
+            <p className="text-[10px] font-bold tracking-[0.2em] text-[#8a8278]">
+              RESTAURANTS
+            </p>
+            <div>
+              <p className="text-sm text-[#777066]">掲載中のお店</p>
+              <p className="mt-2 text-6xl font-bold tracking-[-0.05em] tabular-nums">
+                {data.municipality.meshis.length}
+                <span className="ml-2 text-base font-medium tracking-normal">
+                  件
+                </span>
+              </p>
+            </div>
+            <Link
+              href="/"
+              className="inline-flex items-center gap-2 border-t border-[#d9d4ca] pt-5 text-xs font-bold text-[#806a48] hover:underline"
+            >
+              ほかの地域・料理を探す →
+            </Link>
+          </div>
+        </header>
+
+        <section className="pb-20 pt-12 sm:pb-24 sm:pt-16">
+          <div className="mb-8 border-b border-[#bdb7ad] pb-6 sm:mb-10 sm:flex sm:items-end sm:justify-between">
+            <div>
+              <p className="mb-3 text-xs font-bold tracking-[0.2em] text-[#7a6c56]">
+                DISCOVER
+              </p>
+              <h2 className="text-3xl font-bold leading-tight tracking-tight sm:text-4xl">
+                {data.municipality.name}で見つける、
+                <br className="sm:hidden" />
+                今日の一軒。
+              </h2>
+            </div>
+            <p className="mt-4 text-sm text-[#777066] sm:mt-0">
+              {data.municipality.meshis.length}件
+            </p>
+          </div>
+
+          {data.municipality.meshis.length > 0 ? (
+            <div className="grid grid-cols-1 gap-x-6 gap-y-12 sm:grid-cols-2 lg:grid-cols-3 lg:gap-y-16">
+              {data.municipality?.meshis.map((meshi, i) => {
+                if (meshi == null) {
+                  throw new Error('meshi is null')
+                }
+                return (
+                  <MeshiCard meshi={meshi} key={meshi.id} isEager={i <= 10} />
+                )
+              })}
+            </div>
+          ) : (
+            <div className="border-y border-[#d9d4ca] py-16 text-center">
+              <p className="font-medium">この地域のお店はまだありません</p>
+              <Link
+                href="/"
+                className="mt-3 inline-block text-sm font-medium text-[#806a48] hover:underline"
+              >
+                ほかの地域から探す →
+              </Link>
+            </div>
+          )}
+        </section>
       </div>
-    </div>
+    </main>
   )
 }
 

--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -20,41 +20,108 @@ export default async function Home(props: HomePageProps) {
   const data = await fetchMeshis(10, query) // 初期表示を10件に制限
 
   return (
-    <div className="flex justify-center">
-      <div className="flex flex-col gap-2 md:p-20 px-2 pt-6 pb-24 max-w-[900px]">
-        <div className="text-center mb-4 md:mb-8">
-          <h1 className="mb-2 flex justify-center">
-            <BrandLogo
-              markClassName="size-16 md:size-20"
-              textClassName="text-4xl md:text-5xl"
-            />
-          </h1>
-          <p className="text-gray-600">美味しいごはんを探そう！</p>
+    <main className="min-h-screen bg-[#f5f2eb]">
+      <section className="mx-auto w-full max-w-[1180px] px-4 py-5 sm:px-6 sm:py-8 lg:px-8">
+        <div className="grid overflow-hidden border border-[#2f2b26] bg-white lg:grid-cols-[1.08fr_0.92fr]">
+          <div className="flex min-h-[420px] flex-col justify-between bg-[#24211e] p-7 text-white sm:p-10 lg:min-h-[520px] lg:p-14">
+            <div className="flex items-center justify-between text-[11px] font-bold tracking-[0.2em] text-white/60">
+              <span>OKINAWA FOOD GUIDE</span>
+              <span>MESHI PIYO</span>
+            </div>
+
+            <div className="py-12 lg:py-16">
+              <p className="mb-5 flex items-center gap-3 text-sm text-[#d5a843]">
+                <span className="h-px w-10 bg-current" />
+                沖縄のグルメを、もっと身近に
+              </p>
+              <h1 className="text-balance text-[clamp(3.25rem,8vw,6.75rem)] font-bold leading-[1.03] tracking-[-0.055em]">
+                今日の
+                <br />
+                うまいを、
+                <br />
+                沖縄で。
+              </h1>
+            </div>
+
+            <p className="max-w-md text-sm leading-7 text-white/65 sm:text-base">
+              テレビや記事で紹介された沖縄のお店を、地域や気になる料理から探せます。
+            </p>
+          </div>
+
+          <div className="flex min-h-[360px] flex-col justify-between bg-[#fbfaf7] p-7 sm:p-10 lg:min-h-[520px] lg:p-14">
+            <BrandLogo markClassName="size-12" textClassName="text-3xl" />
+
+            <div className="my-12 lg:my-16">
+              <p className="mb-4 text-xs font-bold tracking-[0.18em] text-muted-foreground">
+                SEARCH
+              </p>
+              <h2 className="max-w-md text-3xl font-bold leading-tight tracking-tight text-[#302b26] sm:text-4xl">
+                店名や料理から、
+                <br />
+                食べたいものを探す。
+              </h2>
+              <SearchInput
+                initialQuery={query}
+                className="mt-8"
+                inputClassName="h-14 rounded-none border-x-0 border-t-0 border-b-[#302b26] bg-transparent pl-9 pr-10 text-base shadow-none focus-visible:ring-0"
+              />
+            </div>
+
+            <div className="flex items-end justify-between border-t border-[#d9d4ca] pt-5">
+              <p className="text-xs leading-5 text-muted-foreground">
+                掲載中の沖縄グルメ
+              </p>
+              <p className="text-3xl font-bold tabular-nums text-[#302b26]">
+                {data.meshis.totalCount}
+                <span className="ml-1 text-sm font-medium">件</span>
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto w-full max-w-[1180px] px-4 pb-20 pt-10 sm:px-6 sm:pb-24 sm:pt-16 lg:px-8">
+        <div className="mb-8 border-b border-[#bdb7ad] pb-6 sm:mb-10 sm:flex sm:items-end sm:justify-between">
+          <div>
+            <p className="mb-3 text-xs font-bold tracking-[0.2em] text-[#7a6c56]">
+              {query ? 'SEARCH RESULTS' : 'DISCOVER'}
+            </p>
+            <h2 className="text-balance text-3xl font-bold leading-tight tracking-tight text-[#302b26] sm:text-4xl">
+              {query ? (
+                <>「{query}」の検索結果</>
+              ) : (
+                <>
+                  沖縄で見つける、
+                  <br className="sm:hidden" />
+                  今日の一軒。
+                </>
+              )}
+            </h2>
+          </div>
+          <p className="mt-4 text-sm text-muted-foreground sm:mt-0">
+            {data.meshis.totalCount}件
+          </p>
         </div>
 
-        {/* 検索結果 */}
-        {query && (
-          <div className="mb-4 text-gray-600">
-            <span className="font-semibold">「{query}」</span>の検索結果：{' '}
-            {data.meshis.totalCount}件
+        {data.meshis.totalCount > 0 ? (
+          <MeshiListContainer
+            key={query || 'all'}
+            initialData={data}
+            loadMoreAction={loadMoreMeshis}
+            query={query}
+          />
+        ) : (
+          <div className="border-y border-[#d9d4ca] py-16 text-center">
+            <p className="font-medium text-[#302b26]">
+              該当するお店が見つかりませんでした
+            </p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              店名や料理名を変えて、もう一度検索してみてください。
+            </p>
           </div>
         )}
-
-        <MeshiListContainer
-          key={query || 'all'}
-          initialData={data}
-          loadMoreAction={loadMoreMeshis}
-          query={query}
-        />
-      </div>
-
-      {/* 検索入力（画面下部固定） */}
-      <div className="fixed bottom-4 left-4 right-4 bg-primary/20 backdrop-blur-sm rounded-2xl shadow-2xl z-50 p-4 md:bottom-6 md:left-6 md:right-6">
-        <div className="max-w-[900px] mx-auto">
-          <SearchInput initialQuery={query} />
-        </div>
-      </div>
-    </div>
+      </section>
+    </main>
   )
 }
 

--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -80,6 +80,19 @@ export default async function Home(props: HomePageProps) {
         </div>
       </section>
 
+      <div className="sticky top-0 z-40 border-y border-[#d9d4ca] bg-[#f5f2eb]/95 backdrop-blur-md">
+        <div className="mx-auto flex w-full max-w-[1180px] items-center gap-4 px-4 py-3 sm:px-6 lg:px-8">
+          <p className="hidden shrink-0 text-[11px] font-bold tracking-[0.18em] text-[#7a6c56] sm:block">
+            FIND YOUR MEAL
+          </p>
+          <SearchInput
+            initialQuery={query}
+            className="ml-auto max-w-xl"
+            inputClassName="h-10 rounded-none border-x-0 border-t-0 border-b-[#8f887d] bg-transparent pl-8 pr-9 text-sm shadow-none focus-visible:ring-0"
+          />
+        </div>
+      </div>
+
       <section className="mx-auto w-full max-w-[1180px] px-4 pb-20 pt-10 sm:px-6 sm:pb-24 sm:pt-16 lg:px-8">
         <div className="mb-8 border-b border-[#bdb7ad] pb-6 sm:mb-10 sm:flex sm:items-end sm:justify-between">
           <div>

--- a/apps/frontend/components/meshi-card.tsx
+++ b/apps/frontend/components/meshi-card.tsx
@@ -3,7 +3,6 @@
 import { MapPin } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
-import { Card, CardContent, CardFooter } from '@/components/ui/card'
 import { type FragmentType, graphql, useFragment } from '@/src/gql'
 
 export const MeshiCardFragment = graphql(`
@@ -31,58 +30,61 @@ export const MeshiCard = (props: Props) => {
   const meshi = useFragment(MeshiCardFragment, props.meshi)
 
   return (
-    <Card className="p-4 max-w-[345px]" key={meshi.id}>
-      <CardContent className="p-0">
-        <div className="flex justify-center">
-          {/* 中央に寄せる */}
-          <Link target="_blank" href={meshi.siteUrl} key={meshi.id}>
+    <article className="group min-w-0" key={meshi.id}>
+      <Link href={`/meshi/${meshi.id}`} className="block">
+        <div className="relative aspect-[4/3] overflow-hidden bg-muted">
+          {meshi.imageUrl && (
             <Image
-              className="h-auto max-w-full rounded-lg"
-              width={313}
-              height={313}
+              className="object-cover transition-transform duration-500 ease-out group-hover:scale-[1.025]"
+              fill
               src={meshi.imageUrl}
-              alt=""
+              alt={`${meshi.storeName}の料理`}
               loading={props.isEager ? 'eager' : 'lazy'}
               fetchPriority={props.isEager ? 'high' : undefined}
+              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 360px"
             />
-          </Link>
+          )}
         </div>
-        <div className="flex flex-row items-center justify-between flex-wrap gap-1 pt-3 pb-1">
+      </Link>
+
+      <div className="pt-4">
+        <div className="flex flex-wrap items-center justify-between gap-2 text-xs">
           {meshi.municipality?.id ? (
             <Link
               href={`/municipality/${meshi.municipality.id}`}
-              className="px-4 py-1 rounded-xl font-bold text-[12px] text-white w-fit bg-primary"
+              className="font-bold text-[#806a48] hover:underline"
             >
-              {meshi.municipality.name}
+              {meshi.municipality.name} →
             </Link>
           ) : (
-            <span className="px-4 py-1 rounded-xl font-bold text-[12px] text-white w-fit bg-gray-400">
+            <span className="font-medium text-muted-foreground">
               {meshi.municipality?.name || '不明'}
             </span>
           )}
-          <div className="flex items-center">
-            <Link
-              href={`https://www.google.com/maps/search/?api=1&query=${meshi?.storeName}`}
-              target="_blank"
-              passHref
-            >
-              <MapPin className="size-6 text-amber-700" fill="#fff" />
-            </Link>
-          </div>
+          <time className="tabular-nums text-muted-foreground">
+            {new Date(meshi.publishedDate).toLocaleDateString('ja-JP')}
+          </time>
         </div>
-      </CardContent>
-      <CardFooter className="p-0">
-        <div className="w-full">
-          <Link href={`/meshi/${meshi.id}`} key={meshi.id}>
-            <p className="font-bold line-clamp-3 text-balance">{meshi.title}</p>
-          </Link>
-          <div className="flex justify-end mt-1">
-            <p className="text-sm text-gray-500">
-              {new Date(meshi.publishedDate).toLocaleDateString('ja-JP')}
-            </p>
-          </div>
-        </div>
-      </CardFooter>
-    </Card>
+
+        <Link href={`/meshi/${meshi.id}`}>
+          <h3 className="mt-3 text-xl font-bold leading-snug tracking-tight text-[#302b26] transition-colors group-hover:text-[#806a48]">
+            {meshi.storeName}
+          </h3>
+          <p className="mt-2 line-clamp-2 text-sm leading-6 text-muted-foreground">
+            {meshi.title}
+          </p>
+        </Link>
+
+        <Link
+          href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(meshi.storeName)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-4 inline-flex items-center gap-1.5 text-xs font-medium text-[#302b26] hover:underline"
+        >
+          <MapPin className="size-3.5" />
+          地図を見る
+        </Link>
+      </div>
+    </article>
   )
 }

--- a/apps/frontend/components/meshi-list-container.tsx
+++ b/apps/frontend/components/meshi-list-container.tsx
@@ -197,8 +197,8 @@ export function MeshiListContainer({
 
   return (
     <>
-      <div className="flex justify-center">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div>
+        <div className="grid grid-cols-1 gap-x-6 gap-y-12 sm:grid-cols-2 lg:grid-cols-3 lg:gap-y-16">
           {meshis.map((meshi, index) => (
             <MeshiCard
               meshi={meshi}

--- a/apps/frontend/components/restaurant-detail.tsx
+++ b/apps/frontend/components/restaurant-detail.tsx
@@ -10,6 +10,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { cache } from 'react'
+import { BrandLogo } from '@/components/brand-logo'
 import { Button } from '@/components/ui/button'
 import { createRevalidatedGraphQLClient } from '@/lib/graphql-client'
 import { graphql } from '@/src/gql'
@@ -79,7 +80,7 @@ export default async function RestaurantDetail({ id }: Props) {
   }
 
   return (
-    <main className="min-h-screen bg-background">
+    <main className="min-h-screen bg-[#f5f2eb] text-[#302b26]">
       <script
         type="application/ld+json"
         // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD is serialized from trusted API fields and escapes HTML delimiters
@@ -95,10 +96,10 @@ export default async function RestaurantDetail({ id }: Props) {
         }}
       />
 
-      <div className="mx-auto w-full max-w-[900px] px-4 py-6 sm:px-6 sm:py-10">
+      <div className="mx-auto w-full max-w-[1180px] px-4 py-5 sm:px-6 sm:py-8 lg:px-8">
         <nav
           aria-label="パンくずリスト"
-          className="mb-6 flex min-w-0 items-center gap-1 text-sm text-muted-foreground"
+          className="mb-5 flex min-w-0 items-center gap-1 text-xs text-[#777066] sm:mb-7"
         >
           <Link href="/" className="shrink-0 hover:text-foreground">
             ホーム
@@ -120,50 +121,58 @@ export default async function RestaurantDetail({ id }: Props) {
           </span>
         </nav>
 
-        <article>
-          <div className="grid items-start gap-7 md:grid-cols-[minmax(0,1.05fr)_minmax(18rem,0.95fr)] md:gap-10">
-            <div className="min-w-0">
+        <article className="overflow-hidden border border-[#2f2b26] bg-[#fbfaf7]">
+          <div className="grid lg:grid-cols-[1.08fr_0.92fr]">
+            <div className="min-w-0 border-b border-[#2f2b26] lg:border-b-0 lg:border-r">
               {meshi.imageUrl ? (
-                <div className="relative aspect-[4/3] w-full overflow-hidden rounded-lg bg-muted shadow-[0_8px_28px_rgba(0,0,0,0.07)]">
+                <div className="relative aspect-[4/3] h-full min-h-[300px] w-full overflow-hidden bg-[#ded9d0]">
                   <Image
                     className="object-cover"
                     src={meshi.imageUrl}
                     alt={`${meshi.storeName}の料理`}
                     fill
                     priority
-                    sizes="(max-width: 768px) 100vw, 480px"
+                    sizes="(max-width: 1024px) 100vw, 640px"
                   />
                 </div>
               ) : (
-                <div className="flex aspect-[4/3] items-center justify-center rounded-lg bg-muted">
+                <div className="flex aspect-[4/3] h-full items-center justify-center bg-[#ded9d0]">
                   <p className="text-muted-foreground">画像がありません</p>
                 </div>
               )}
             </div>
 
-            <div className="min-w-0 md:pt-2">
-              {meshi.municipality && (
-                <Link
-                  href={`/municipality/${meshi.municipality.id}`}
-                  className="mb-3 inline-flex items-center gap-1.5 rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/15"
-                >
-                  <MapPin aria-hidden="true" className="size-3.5" />
-                  {meshi.municipality.name}
-                </Link>
-              )}
+            <div className="flex min-w-0 flex-col justify-between p-7 sm:p-10 lg:min-h-[520px] lg:p-12">
+              <div>
+                <div className="mb-10 flex items-center justify-between gap-4">
+                  <BrandLogo markClassName="size-9" textClassName="text-2xl" />
+                  <span className="text-[10px] font-bold tracking-[0.18em] text-[#8a8278]">
+                    OKINAWA FOOD GUIDE
+                  </span>
+                </div>
+                {meshi.municipality && (
+                  <Link
+                    href={`/municipality/${meshi.municipality.id}`}
+                    className="mb-4 inline-flex items-center gap-2 text-xs font-bold text-[#806a48] hover:underline"
+                  >
+                    <MapPin aria-hidden="true" className="size-3.5" />
+                    {meshi.municipality.name} →
+                  </Link>
+                )}
 
-              <h1 className="text-balance text-3xl font-bold leading-tight tracking-tight text-foreground sm:text-4xl">
-                {meshi.storeName}
-              </h1>
-              <p className="mt-4 text-pretty leading-7 text-muted-foreground">
-                {meshi.title}
-              </p>
+                <h1 className="text-balance text-4xl font-bold leading-[1.15] tracking-[-0.04em] sm:text-5xl">
+                  {meshi.storeName}
+                </h1>
+                <p className="mt-5 text-pretty leading-8 text-[#6f685f]">
+                  {meshi.title}
+                </p>
+              </div>
 
-              <div className="mt-6 grid gap-3 sm:grid-cols-2 md:grid-cols-1 lg:grid-cols-2">
+              <div className="mt-10 grid gap-3 sm:grid-cols-2">
                 <Button
                   asChild
                   size="lg"
-                  className="bg-[#665238] text-white hover:bg-[#58462f] hover:opacity-100"
+                  className="h-12 rounded-none bg-[#302b26] text-white hover:bg-[#4a433c] hover:opacity-100"
                 >
                   <Link href={mapUrl} target="_blank" rel="noopener noreferrer">
                     <MapPin aria-hidden="true" className="mr-2 size-4" />
@@ -175,7 +184,7 @@ export default async function RestaurantDetail({ id }: Props) {
                     asChild
                     variant="outline"
                     size="lg"
-                    className="bg-background"
+                    className="h-12 rounded-none border-[#aaa298] bg-transparent hover:bg-[#eeeae2]"
                   >
                     <Link
                       href={meshi.siteUrl}
@@ -194,53 +203,62 @@ export default async function RestaurantDetail({ id }: Props) {
             </div>
           </div>
 
-          <section className="mt-10 border-t pt-8 sm:mt-12 sm:pt-10">
-            <h2 className="flex items-center gap-2 text-lg font-bold">
-              <Store aria-hidden="true" className="size-5 text-primary" />
-              店舗情報
-            </h2>
-            <dl className="mt-5 divide-y rounded-lg border bg-card px-5 shadow-[0_4px_18px_rgba(0,0,0,0.04)] sm:px-6">
-              <div className="grid gap-1 py-4 sm:grid-cols-[7rem_1fr] sm:gap-4">
-                <dt className="text-sm font-medium text-muted-foreground">
-                  所在地
-                </dt>
-                <dd className="text-sm leading-6">{meshi.address}</dd>
+          <section className="border-t border-[#2f2b26] p-7 sm:p-10 lg:p-12">
+            <div className="grid gap-8 lg:grid-cols-[0.42fr_1fr] lg:gap-14">
+              <div>
+                <p className="mb-3 text-[11px] font-bold tracking-[0.2em] text-[#806a48]">
+                  INFORMATION
+                </p>
+                <h2 className="flex items-center gap-2 text-2xl font-bold">
+                  <Store aria-hidden="true" className="size-5" />
+                  店舗情報
+                </h2>
               </div>
-              {meshi.municipality && (
-                <div className="grid gap-1 py-4 sm:grid-cols-[7rem_1fr] sm:gap-4">
-                  <dt className="text-sm font-medium text-muted-foreground">
-                    エリア
-                  </dt>
-                  <dd className="text-sm">
-                    <Link
-                      href={`/municipality/${meshi.municipality.id}`}
-                      className="font-medium text-primary underline-offset-4 hover:underline"
-                    >
-                      {meshi.municipality.name}
-                    </Link>
-                  </dd>
-                </div>
-              )}
-              <div className="grid gap-1 py-4 sm:grid-cols-[7rem_1fr] sm:gap-4">
-                <dt className="text-sm font-medium text-muted-foreground">
-                  紹介日
-                </dt>
-                <dd className="flex items-center gap-2 text-sm">
-                  <CalendarDays
-                    aria-hidden="true"
-                    className="size-4 text-primary"
-                  />
-                  <time dateTime={publishedDate.toISOString()}>
-                    {publishedDateLabel}
-                  </time>
-                </dd>
-              </div>
-            </dl>
+              <div>
+                <dl className="divide-y divide-[#d9d4ca] border-y border-[#8f887d]">
+                  <div className="grid gap-1 py-5 sm:grid-cols-[7rem_1fr] sm:gap-4">
+                    <dt className="text-sm font-medium text-[#777066]">
+                      所在地
+                    </dt>
+                    <dd className="text-sm leading-6">{meshi.address}</dd>
+                  </div>
+                  {meshi.municipality && (
+                    <div className="grid gap-1 py-5 sm:grid-cols-[7rem_1fr] sm:gap-4">
+                      <dt className="text-sm font-medium text-[#777066]">
+                        エリア
+                      </dt>
+                      <dd className="text-sm">
+                        <Link
+                          href={`/municipality/${meshi.municipality.id}`}
+                          className="font-medium text-[#806a48] underline-offset-4 hover:underline"
+                        >
+                          {meshi.municipality.name}
+                        </Link>
+                      </dd>
+                    </div>
+                  )}
+                  <div className="grid gap-1 py-5 sm:grid-cols-[7rem_1fr] sm:gap-4">
+                    <dt className="text-sm font-medium text-[#777066]">
+                      紹介日
+                    </dt>
+                    <dd className="flex items-center gap-2 text-sm">
+                      <CalendarDays
+                        aria-hidden="true"
+                        className="size-4 text-[#806a48]"
+                      />
+                      <time dateTime={publishedDate.toISOString()}>
+                        {publishedDateLabel}
+                      </time>
+                    </dd>
+                  </div>
+                </dl>
 
-            <p className="mt-4 flex items-start gap-2 rounded-lg bg-muted/70 px-4 py-3 text-xs leading-5 text-muted-foreground">
-              <Info aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
-              営業時間・定休日・提供状況は変更される場合があります。訪問前に掲載元や店舗の最新情報をご確認ください。
-            </p>
+                <p className="mt-5 flex items-start gap-2 text-xs leading-5 text-[#777066]">
+                  <Info aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
+                  営業時間・定休日・提供状況は変更される場合があります。訪問前に掲載元や店舗の最新情報をご確認ください。
+                </p>
+              </div>
+            </div>
           </section>
         </article>
       </div>

--- a/apps/frontend/components/search-input.tsx
+++ b/apps/frontend/components/search-input.tsx
@@ -6,16 +6,23 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
 
 type SearchInputProps = {
   initialQuery?: string
+  className?: string
+  inputClassName?: string
 }
 
 /**
  * SearchInput component for search page
  * Updates URL query parameter when user types
  */
-export function SearchInput({ initialQuery = '' }: SearchInputProps) {
+export function SearchInput({
+  initialQuery = '',
+  className,
+  inputClassName,
+}: SearchInputProps) {
   const router = useRouter()
   const searchParams = useSearchParams()
   const [searchTerm, setSearchTerm] = useState(initialQuery)
@@ -44,15 +51,15 @@ export function SearchInput({ initialQuery = '' }: SearchInputProps) {
   }
 
   return (
-    <div className="relative w-full">
+    <div className={cn('relative w-full', className)}>
       <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
       <Input
         type="text"
         placeholder="お店の名前や料理を検索..."
         value={searchTerm}
         onChange={(e) => setSearchTerm(e.target.value)}
-        className="w-full pl-10 pr-10 text-base"
-        aria-label="Search restaurants"
+        className={cn('w-full pl-10 pr-10 text-base', inputClassName)}
+        aria-label="お店や料理を検索"
       />
       {searchTerm && (
         <Button
@@ -60,7 +67,7 @@ export function SearchInput({ initialQuery = '' }: SearchInputProps) {
           size="icon"
           className="absolute right-1 top-1/2 h-8 w-8 -translate-y-1/2"
           onClick={handleClear}
-          aria-label="Clear search"
+          aria-label="検索内容をクリア"
         >
           <X className="h-4 w-4" />
         </Button>


### PR DESCRIPTION
## 変更内容
- トップページのヒーローをエディトリアル調の2カラム構成へ刷新
- 検索欄を固定フローティング表示からヒーロー内へ移動
- 店舗一覧を余白重視のレスポンシブグリッドへ変更
- 店舗カードの情報階層と導線を整理
- 検索結果が0件の場合の案内を追加

## 目的
参考デザインのタイポグラフィと余白感を取り入れつつ、飯ぴよのブランドカラーに合わせた落ち着いたトップページに改善します。

## ユーザーへの影響
- 店名や料理からの検索導線がページ上部で明確になります
- 店舗名、地域、掲載日、地図への導線を一覧から確認しやすくなります
- PC・タブレット・スマートフォンでカード数が最適化されます

## 確認内容
- Biome（対象ファイル）
- frontend typecheck
- frontend production build
- デスクトップ・モバイル表示
- 検索クエリのURL反映